### PR TITLE
Ajout du support des exceptions PHP

### DIFF
--- a/SimpleSQL.php
+++ b/SimpleSQL.php
@@ -3,6 +3,7 @@
  * SQL/SimpleSQL.php
  *
  * @author Jérémy 'Jejem' Desvages <jejem@phyrexia.org>
+ * @author Frédéric Le Barzic <fred@lebarzic.fr>
  * @copyright Jérémy 'Jejem' Desvages
  * @license The MIT License (MIT)
  * @version 1.0.0
@@ -16,7 +17,6 @@ class SimpleSQL {
 	private $link = false;
 	private $db = NULL;
 	private $result = false;
-	private $useException = true;
 
 	public $sqlHost;
 	public $sqlUser;
@@ -34,15 +34,6 @@ class SimpleSQL {
 		mysqli_report(MYSQLI_REPORT_STRICT);
 	}
 
-	private function fatalError($msg) {
-		if (is_array($this->alertEmails) && count($this->alertEmails) > 0) {
-			foreach ($this->alertEmails as $alertEmail)
-				mail($alertEmail, '[SimpleSQL] An error occured', 'An error occured:'."\n\n".$msg, 'X-Mailer: PHP/'.phpversion());
-		}
-
-		trigger_error($msg, E_USER_ERROR);
-	}
-
 	private function checkLink() {
 		if ($this->link)
 			return;
@@ -52,18 +43,7 @@ class SimpleSQL {
 			$this->selectDB($this->sqlBase);
 			$this->doQuery('SET NAMES %1', 'utf8');
 		} catch (\mysqli_sql_exception $e) {
-			if ($this->useException) {
-				throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
-			}
-
-			$this->fatalError('<strong>Error:</strong><br />Link to SQL server failed.<br />Please try again later.');
-			return false;
-		}  catch (SimpleSQLException $e) {
-			if ($this->useException) {
-				throw new $e;
-			}
-
-			$this->fatalError('<strong>Error:</strong><br />Could not select database.<br />Please try again later.');
+			throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
 		}
 	}
 
@@ -97,22 +77,14 @@ class SimpleSQL {
 
 			$this->result = mysqli_query($this->link, $query);
 			if ($this->result === false) {
-				if ($this->useException) {
-					throw new SimpleSQLException(mysqli_error($this->link), mysqli_errno($this->link), null, $query);
-				}
-
-				$this->fatalError('<strong>Error:</strong><br />('.mysqli_errno($this->link).') '.mysqli_error($this->link).'<br />Query: '.$query);
+				throw new SimpleSQLException(mysqli_error($this->link), mysqli_errno($this->link), null, $query);
 			}
 
 			$this->totalQueries += 1;
 
 			return $this->result;
 		} catch (\mysqli_sql_exception $e) {
-			if ($this->useException) {
-				throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e, $query);
-			}
-
-			$this->fatalError('<strong>Error:</strong><br />(' . $e->getCode() . ') ' . $e->getMessage() . '<br />Query: ' . $query);
+			throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e, $query);
 		}
 	}
 
@@ -125,11 +97,7 @@ class SimpleSQL {
 		try {
 			return mysqli_fetch_assoc($this->result);
 		} catch (\mysqli_sql_exception $e) {
-			if ($this->useException) {
-				throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
-			}
-
-			$this->fatalError('<strong>Error:</strong><br />(' . $e->getCode() . ') ' . $e->getMessage());
+			throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
 		}
 	}
 
@@ -146,11 +114,7 @@ class SimpleSQL {
 
 			return $ret;
 		} catch (\mysqli_sql_exception $e) {
-			if ($this->useException) {
-				throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
-			}
-
-			$this->fatalError('<strong>Error:</strong><br />(' . $e->getCode() . ') ' . $e->getMessage());
+			throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
 		}
 	}
 
@@ -163,11 +127,7 @@ class SimpleSQL {
 		try {
 			return mysqli_num_rows($this->result);
 		} catch (\mysqli_sql_exception $e) {
-			if ($this->useException) {
-				throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
-			}
-
-			$this->fatalError('<strong>Error:</strong><br />(' . $e->getCode() . ') ' . $e->getMessage());
+			throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
 		}
 	}
 
@@ -177,11 +137,7 @@ class SimpleSQL {
 		try {
 			return mysqli_insert_id($this->link);
 		} catch (\mysqli_sql_exception $e) {
-			if ($this->useException) {
-				throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
-			}
-
-			$this->fatalError('<strong>Error:</strong><br />(' . $e->getCode() . ') ' . $e->getMessage());
+			throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
 		}
 	}
 

--- a/SimpleSQL.php
+++ b/SimpleSQL.php
@@ -16,6 +16,7 @@ class SimpleSQL {
 	private $link = false;
 	private $db = NULL;
 	private $result = false;
+	private $useException = true;
 
 	public $sqlHost;
 	public $sqlUser;
@@ -29,6 +30,8 @@ class SimpleSQL {
 		$this->sqlUser = $user;
 		$this->sqlPass = $pass;
 		$this->sqlBase = $base;
+
+		mysqli_report(MYSQLI_REPORT_STRICT);
 	}
 
 	private function fatalError($msg) {
@@ -44,26 +47,37 @@ class SimpleSQL {
 		if ($this->link)
 			return;
 
-		$this->link = @mysqli_connect($this->sqlHost, $this->sqlUser, $this->sqlPass);
+		try {
+			$this->link = mysqli_connect($this->sqlHost, $this->sqlUser, $this->sqlPass);
+			$this->selectDB($this->sqlBase);
+			$this->doQuery('SET NAMES %1', 'utf8');
+		} catch (\mysqli_sql_exception $e) {
+			if ($this->useException) {
+				throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
+			}
 
-		if (! $this->link)
 			$this->fatalError('<strong>Error:</strong><br />Link to SQL server failed.<br />Please try again later.');
+			return false;
+		}  catch (SimpleSQLException $e) {
+			if ($this->useException) {
+				throw new $e;
+			}
 
-		if (! $this->selectDB($this->sqlBase))
 			$this->fatalError('<strong>Error:</strong><br />Could not select database.<br />Please try again later.');
-
-		$this->doQuery('SET NAMES %1', 'utf8');
+		}
 	}
 
 	public function selectDB($db) {
 		$this->checkLink();
 
-		if (! @mysqli_select_db($this->link, $db))
-			return false;
+		try {
+			mysqli_select_db($this->link, $db);
+			$this->db = $db;
 
-		$this->db = $db;
-
-		return true;
+			return true;
+		} catch (\mysqli_sql_exception $e) {
+			throw new SimpleSQLException('Could not select database, please try again later.');
+		}
 	}
 
 	public function doQuery() {
@@ -75,16 +89,31 @@ class SimpleSQL {
 		$query = preg_replace_callback('/@([0-9]+)/s', function($matches) use ($args) { return ((! array_key_exists($matches[1], $args))?'@'.$matches[1]:(is_null($args[$matches[1]])?NULL:'`'.@mysqli_real_escape_string($this->link, $args[$matches[1]]).'`')); }, $query);
 		$query = preg_replace_callback('/%([0-9]+)/s', function($matches) use ($args) { return ((! array_key_exists($matches[1], $args))?'%'.$matches[1]:(is_null($args[$matches[1]])?NULL:'"'.@mysqli_real_escape_string($this->link, $args[$matches[1]]).'"')); }, $query);
 
-		if (is_resource($this->result)) {
-			@mysqli_free_result($this->result);
-			$this->result = false;
+		try {
+			if (is_resource($this->result)) {
+				mysqli_free_result($this->result);
+				$this->result = false;
+			}
+
+			$this->result = mysqli_query($this->link, $query);
+			if ($this->result === false) {
+				if ($this->useException) {
+					throw new SimpleSQLException(mysqli_error($this->link), mysqli_errno($this->link), null, $query);
+				}
+
+				$this->fatalError('<strong>Error:</strong><br />('.mysqli_errno($this->link).') '.mysqli_error($this->link).'<br />Query: '.$query);
+			}
+
+			$this->totalQueries += 1;
+
+			return $this->result;
+		} catch (\mysqli_sql_exception $e) {
+			if ($this->useException) {
+				throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e, $query);
+			}
+
+			$this->fatalError('<strong>Error:</strong><br />(' . $e->getCode() . ') ' . $e->getMessage() . '<br />Query: ' . $query);
 		}
-
-		$this->result = @mysqli_query($this->link, $query) or $this->fatalError('<strong>Error:</strong><br />('.@mysqli_errno($this->link).') '.@mysqli_error($this->link).'<br />Query: '.$query);
-
-		$this->totalQueries += 1;
-
-		return $this->result;
 	}
 
 	public function fetchResult() {
@@ -93,7 +122,15 @@ class SimpleSQL {
 		if (! $this->result)
 			return false;
 
-		return @mysqli_fetch_assoc($this->result);
+		try {
+			return mysqli_fetch_assoc($this->result);
+		} catch (\mysqli_sql_exception $e) {
+			if ($this->useException) {
+				throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
+			}
+
+			$this->fatalError('<strong>Error:</strong><br />(' . $e->getCode() . ') ' . $e->getMessage());
+		}
 	}
 
 	public function fetchAllResults() {
@@ -102,11 +139,19 @@ class SimpleSQL {
 		if (! $this->result)
 			return false;
 
-		$ret = array();
-		while ($buf = @mysqli_fetch_assoc($this->result))
-			$ret[] = $buf;
+		try {
+			$ret = array();
+			while ($buf = mysqli_fetch_assoc($this->result))
+				$ret[] = $buf;
 
-		return $ret;
+			return $ret;
+		} catch (\mysqli_sql_exception $e) {
+			if ($this->useException) {
+				throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
+			}
+
+			$this->fatalError('<strong>Error:</strong><br />(' . $e->getCode() . ') ' . $e->getMessage());
+		}
 	}
 
 	public function numRows() {
@@ -115,16 +160,36 @@ class SimpleSQL {
 		if (! $this->result)
 			return false;
 
-		return @mysqli_num_rows($this->result);
+		try {
+			return mysqli_num_rows($this->result);
+		} catch (\mysqli_sql_exception $e) {
+			if ($this->useException) {
+				throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
+			}
+
+			$this->fatalError('<strong>Error:</strong><br />(' . $e->getCode() . ') ' . $e->getMessage());
+		}
 	}
 
 	public function insertID() {
 		$this->checkLink();
 
-		return @mysqli_insert_id($this->link);
+		try {
+			return mysqli_insert_id($this->link);
+		} catch (\mysqli_sql_exception $e) {
+			if ($this->useException) {
+				throw new SimpleSQLException($e->getMessage(), $e->getCode(), $e);
+			}
+
+			$this->fatalError('<strong>Error:</strong><br />(' . $e->getCode() . ') ' . $e->getMessage());
+		}
 	}
 
 	public function totalQueries() {
 		return $this->totalQueries;
+	}
+
+	public function setUseException($value) {
+		$this->useException = $value;
 	}
 }

--- a/SimpleSQLException.php
+++ b/SimpleSQLException.php
@@ -3,13 +3,12 @@
  * SQL/SimpleSQLException.php
  *
  * @author Frédéric Le Barzic <fred@lebarzic.fr>
- * @copyright Frédéric Le Barzic
+ * @copyright Jérémy 'Jejem' Desvages
  * @license The MIT License (MIT)
  * @version 1.0.0
  **/
 
 namespace Phyrexia\SQL;
-
 
 class SimpleSQLException extends \Exception
 {

--- a/SimpleSQLException.php
+++ b/SimpleSQLException.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * SQL/SimpleSQLException.php
+ *
+ * @author Frédéric Le Barzic <fred@lebarzic.fr>
+ * @copyright Frédéric Le Barzic
+ * @license The MIT License (MIT)
+ * @version 1.0.0
+ **/
+
+namespace Phyrexia\SQL;
+
+
+class SimpleSQLException extends \Exception
+{
+	protected $query;
+
+	public function __construct($message = "", $code = 0, Exception $previous = null, $query = null)
+	{
+		parent::__construct($message, $code, $previous);
+		$this->query = $query;
+	}
+
+	public function getQuery()
+	{
+		return $this->query;
+	}
+
+}


### PR DESCRIPTION
Tout est dans le titre.
J'ai gardé la possibilité de rester avec des fatalErrors via la methode 

```
  $simpleSQL->setUseException(false);
```

Par contre on perds l'envoie d'email en cas d'utilisation des Exceptions PHP vue que l'on déporte la gestion des erreurs !

See you soon !
Fred
