### PR TITLE
Add close() method

### DIFF
--- a/src/SimpleSQL.php
+++ b/src/SimpleSQL.php
@@ -45,6 +45,15 @@ class SimpleSQL {
 		return new SimpleSQL($base, $host, $port, $user, $pass);
 	}
 
+	public function close() {
+		$thread_id = mysqli_thread_id($this->getLink());
+		if ($thread_id !== false) {
+			mysqli_kill($this->getLink(), $thread_id);
+		}
+		@mysqli_close($this->getLink());
+		unset($this->links[$this->currentLinkType]);
+	}
+
 	public function getForceMaster() {
 		return $this->forceMaster;
 	}


### PR DESCRIPTION
Sometimes i need to actually close the sql connection, for example when i'm forking the php process.

In top of closing the sql connection, you need to remove the link attribute, i did "unset($this->links[$this->currentLinkType]);" but i'm not sure it is the right thing to do.
